### PR TITLE
Refactor paths and cleanup imports

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+
+# Base project root (two levels up from this file)
+PROJECT_ROOT = Path(os.getenv("PROJECT_ROOT", Path(__file__).resolve().parent.parent))
+
+DATA_DIR = PROJECT_ROOT / "data"
+SAMPLE_DATA_DIR = DATA_DIR / "sample"
+FORMAT_DIR = DATA_DIR / "format"
+DEFAULT_FORMAT_FILE = FORMAT_DIR / "サンプルテスト調書フォーマット.xlsx"

--- a/src/excel_format_node.py
+++ b/src/excel_format_node.py
@@ -1,6 +1,5 @@
 from state import State
 from understand_format import build_workflow, ExcelFormFields, ValidationResult
-from pathlib import Path
 
 def run_excel_format_workflow_node(state: State) -> dict:
     """

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,5 +1,3 @@
-import sys
-import langgraph.prebuilt
 import logging
 
 logging.basicConfig(
@@ -12,7 +10,7 @@ logging.basicConfig(
 
 """Module for defining the agent's workflow graph and human interaction nodes."""
 
-from langgraph.graph import StateGraph, END
+from langgraph.graph import StateGraph
 from state import State
 from react_node import react_node
 from update_format_node import update_format_node

--- a/src/react_node.py
+++ b/src/react_node.py
@@ -3,9 +3,7 @@ from pydantic import BaseModel, Field
 from state import State
 from langchain_core.runnables import RunnableConfig
 from typing import Any, Dict, Sequence, TypedDict, Union
-from langgraph.types import Command
-from langchain_core.messages import ToolMessage, HumanMessage, BaseMessage
-import langchain
+from langchain_core.messages import HumanMessage, BaseMessage
 from langchain_community.tools import tool
 from langchain_openai import ChatOpenAI
 
@@ -16,13 +14,12 @@ from langgraph.prebuilt.interrupt import (
     HumanResponse,
 )
 from langgraph.types import interrupt
-import httpx
 import base64
 import os
 import fitz
 import logging
 
-from langgraph.graph.message import add_messages
+from config import SAMPLE_DATA_DIR
 from langgraph.managed import IsLastStep, RemainingSteps
 from typing_extensions import Annotated
 
@@ -107,7 +104,7 @@ def react_node(state: State, config: RunnableConfig) -> Dict[str, Any]:
     logger.info(f"--- Iteration {current_iteration}/{state.max_iterations} ---")
 
     if state.sample_data_path:
-        data_path = os.path.join("C:\\Users\\nyham\\work\\sampletest_3\\agent-inbox-langgraph-example\\data\\sample",state.sample_data_path)
+        data_path = os.path.join(SAMPLE_DATA_DIR, state.sample_data_path)
         sample_num = len(os.listdir(data_path))
 
     image_data = []

--- a/src/state.py
+++ b/src/state.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import  field
-from typing import TypedDict, Annotated
-from langgraph.graph.message import add_messages
+from typing import Annotated
 from langchain_core.pydantic_v1 import BaseModel, Field
-import pandas as pd
-import os
-from pathlib import Path
+
+from config import DEFAULT_FORMAT_FILE, FORMAT_DIR
 
 # _DEFAULT_EXCEL_FORMAT_DIR = Path("C:/Users/nyham/work/sampletest_3/agent-inbox-langgraph-example/data/format") # コメントアウト
 
@@ -41,10 +38,10 @@ class State(BaseModel):
     sample_data_path: str = Field(default="")
     iter_data: Annotated[list, append_iter_data] = Field(default=[])
     data_info: dict = Field(default_factory=dict)
-    format_path: str = Field(default="C:\\\\Users\\\\nyham\\\\work\\\\sampletest_3\\\\agent-inbox-langgraph-example\\\\data\\\\format\\\\サンプルテスト調書フォーマット.xlsx")
+    format_path: str = Field(default=str(DEFAULT_FORMAT_FILE))
     df: list = Field(default=[])
-    excel_file: str = Field(default="C:\\\\Users\\\\nyham\\\\work\\\\sampletest_3\\\\agent-inbox-langgraph-example\\\\data\\\\format\\\\サンプルテスト調書フォーマット.xlsx", description="Excelファイルパス（Excel入力欄特定ワークフロー用）")
-    output_dir: str = Field(default="C:\\\\Users\\\\nyham\\\\work\\\\sampletest_3\\\\agent-inbox-langgraph-example\\\\data\\\\format", description="出力ディレクトリ（Excel入力欄特定ワークフロー用）")
+    excel_file: str = Field(default=str(DEFAULT_FORMAT_FILE), description="Excelファイルパス（Excel入力欄特定ワークフロー用）")
+    output_dir: str = Field(default=str(FORMAT_DIR), description="出力ディレクトリ（Excel入力欄特定ワークフロー用）")
     output_excel_path: str = Field(default="", description="出力Excelファイルパス（Excel入力欄特定ワークフロー用）")
     excel_max_iterations: int = Field(default=5, description="Excel入力欄特定ワークフローの最大反復回数")
     excel_format_result: dict = Field(default_factory=dict, description="Excel入力欄特定ワークフローの最終結果（辞書形式）")

--- a/src/understand_format.py
+++ b/src/understand_format.py
@@ -8,11 +8,10 @@ import base64
 import logging
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Any, TypedDict, Annotated, Literal, Optional
+from typing import Dict, List, Literal, Optional, TypedDict
 
 # LangChain関連のインポート
-from langchain_core.messages import HumanMessage, SystemMessage
-from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
 from pydantic import BaseModel, Field
@@ -567,9 +566,6 @@ def validate_with_multimodal_llm(state: ExcelFormState) -> ExcelFormState:
         
         final_output_dir = base_save_path / "format_data"
         final_output_dir.mkdir(exist_ok=True, parents=True)
-        
-        # 推定された入力欄情報
-        structured_fields = state["structured_fields"]
         
         # マルチモーダルLLMクライアントの初期化（structured_output使用）
         llm = ChatOpenAI(

--- a/src/update_format_node.py
+++ b/src/update_format_node.py
@@ -1,13 +1,9 @@
 import logging
-from langgraph.prebuilt import create_react_agent
 from state import State
-from langchain_core.runnables import RunnableConfig
-from typing import Any, Dict, List
-from langgraph.types import Command
-from langchain_core.messages import ToolMessage, HumanMessage, AIMessage
+from typing import List
+from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, Field, RootModel
-import json
+from pydantic import BaseModel
 import shutil # shutil をインポート
 from datetime import datetime # datetime をインポート
 

--- a/src/webapp.py
+++ b/src/webapp.py
@@ -1,7 +1,6 @@
 from typing import List
 from fastapi import FastAPI, File, UploadFile
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
 import os
 import asyncio
 from pathlib import Path


### PR DESCRIPTION
## Summary
- centralize filesystem paths in new `config.py`
- update `State` to use path constants
- remove hard-coded path in `react_node`
- drop unused imports across modules

## Testing
- `ruff check src`


------
https://chatgpt.com/codex/tasks/task_e_684626a3bf4c8322a5a420b981e15cbc